### PR TITLE
Allow safe built-ins

### DIFF
--- a/src/cobble/loader.py
+++ b/src/cobble/loader.py
@@ -64,13 +64,53 @@ def load(root, build_dir):
     def _build_conf_plugin_path(*paths):
         sys.path += [project.inpath(p) for p in paths]
 
+    allowed_builtins = {
+        'abs': abs,
+        'all': all,
+        'any': any,
+        'ascii': ascii,
+        'bin': bin,
+        'bool': bool,
+        'chr': chr,
+        'dict': dict,
+        'divmod': divmod,
+        'enumerate': enumerate,
+        'filter': filter,
+        'float': float,
+        'format': format,
+        'frozenset': frozenset,
+        'hash': hash,
+        'hex': hex,
+        'int': int,
+        'iter': iter,
+        'len': len,
+        'list': list,
+        'map': map,
+        'max': max,
+        'min': min,
+        'next': next,
+        'oct': oct,
+        'ord': ord,
+        'pow': pow,
+        'print': print,
+        'range': range,
+        'repr': repr,
+        'reversed': reversed,
+        'round': round,
+        'set': set,
+        'sorted': sorted,
+        'str': str,
+        'sum': sum,
+        'tuple': tuple,
+        'zip': zip,
+    }
+
     # Read in BUILD.conf and eval it for its side effects
     _compile_and_exec(
         path = project.inpath('BUILD.conf'),
         kind = 'BUILD.conf file',
         globals = {
-            # Block access to builtins. TODO: this might be too aggressive.
-            '__builtins__': {},
+            '__builtins__': allowed_builtins,
 
             'seed': _build_conf_seed,
             'install': _build_conf_install,
@@ -100,8 +140,7 @@ def load(root, build_dir):
         # Prepare the global environment for eval-ing the package. We provide
         # a few variables by default:
         pkg_env = {
-            # Block access to builtins. TODO: this might be too aggressive.
-            '__builtins__': {},
+            '__builtins__': allowed_builtins,
 
             # Easy access to the path from the build dir to the package
             'PKG': package.inpath(),
@@ -204,4 +243,3 @@ def _compile_and_exec(path, kind, globals):
                     limit = limit,
                     kind = kind,
                     path = path) from exc_info[1]
-


### PR DESCRIPTION
While working on plugins and build files I found myself enabling 'print' to aid debugging/experimentation. This diff enables a subset of safe builtins which, some of which are already reachable through syntax (dicts, lists, formatting), which may or may not be useful when writing BUILD files.